### PR TITLE
Fix curly braces is deprecated

### DIFF
--- a/lib/Horde/Crypt/Blowfish/Php/Base.php
+++ b/lib/Horde/Crypt/Blowfish/Php/Base.php
@@ -328,7 +328,7 @@ abstract class Horde_Crypt_Blowfish_Php_Base
         for ($i = 0; $i < 18; ++$i) {
             $data = 0;
             for ($j = 4; $j > 0; --$j) {
-                $data = $data << 8 | ord($key{$k});
+                $data = $data << 8 | ord($key[$k]);
                 $k = ($k + 1) % $len;
             }
             $this->_P[$i] ^= $data;


### PR DESCRIPTION
With 7.4.0RC3

```
$ phpunit
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

.................................SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS  63 / 230 ( 27%)
SSSE........................................................... 126 / 230 ( 54%)
..............SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS........ 189 / 230 ( 82%)
.........................................                       230 / 230 (100%)

Time: 256 ms, Memory: 6,00MB

There was 1 error:

1) Horde_Crypt_Blowfish_CbcTest::testPhpDriver with data set #0 (array(Binary String: 0x0000000000000000, Binary String: 0xe4597a95ce318f00, Binary String: 0x0000000000000...0000000))
Array and string offset access syntax with curly braces is deprecated

/work/GIT/horde/Crypt_Blowfish/lib/Horde/Crypt/Blowfish/Php/Base.php:331
/usr/share/pear/Horde/Test/Autoload.php:51
/usr/share/pear/Horde/Test/Autoload.php:51
/work/GIT/horde/Crypt_Blowfish/lib/Horde/Crypt/Blowfish/Php/Cbc.php:31
/usr/share/pear/Horde/Test/Autoload.php:51
/work/GIT/horde/Crypt_Blowfish/lib/Horde/Crypt/Blowfish/Php.php:65
/work/GIT/horde/Crypt_Blowfish/lib/Horde/Crypt/Blowfish/Php.php:44
/work/GIT/horde/Crypt_Blowfish/lib/Horde/Crypt/Blowfish.php:110
/work/GIT/horde/Crypt_Blowfish/test/Horde/Crypt/Blowfish/CbcTest.php:78
/work/GIT/horde/Crypt_Blowfish/test/Horde/Crypt/Blowfish/CbcTest.php:47

ERRORS!
Tests: 230, Assertions: 323, Errors: 1, Skipped: 74.

```