### PR TITLE
On some newer systems blowfish is not supported anymore

### DIFF
--- a/lib/Horde/Crypt/Blowfish/Openssl.php
+++ b/lib/Horde/Crypt/Blowfish/Openssl.php
@@ -26,7 +26,8 @@ class Horde_Crypt_Blowfish_Openssl extends Horde_Crypt_Blowfish_Base
      */
     public static function supported()
     {
-        return extension_loaded('openssl');
+        // bf-* ciphers might not be supported on all systems
+        return extension_loaded('openssl') && array_search('bf-cbc', openssl_get_cipher_methods());
     }
 
     /**


### PR DESCRIPTION
In particular Centos 9 does not support this option.

This causes some very hard to debug issues, since openssl_encrypt just returns false and empty data is stored in the session. This causes for instance the login to fail, as reported by others in https://www.mail-archive.com/imp@lists.horde.org/msg11031.html.