### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Crypt/Blowfish.php
+++ b/lib/Horde/Crypt/Blowfish.php
@@ -29,6 +29,7 @@
  * @property string $key  The encryption key in use.
  * @property mixed $iv  The initialization vector (false if using 'ecb').
  */
+#[\AllowDynamicProperties]
 class Horde_Crypt_Blowfish
 {
     // Constants for 'ignore' parameter of constructor.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Crypt/Blowfish/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Crypt/Blowfish/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde CryptoBlowfish Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Crypt/Blowfish/CbcTest.php
+++ b/test/Horde/Crypt/Blowfish/CbcTest.php
@@ -27,18 +27,6 @@ class Horde_Crypt_Blowfish_CbcTest extends Horde_Test_Case
     /**
      * @dataProvider vectorProvider
      */
-    public function testMcryptDriver($vector)
-    {
-        if (!Horde_Crypt_Blowfish_Mcrypt::supported()) {
-            $this->markTestSkipped();
-        }
-
-        $this->_doTest($vector, Horde_Crypt_Blowfish::IGNORE_OPENSSL);
-    }
-
-    /**
-     * @dataProvider vectorProvider
-     */
     public function testPhpDriver($vector)
     {
         $this->_doTest(

--- a/test/Horde/Crypt/Blowfish/EcbTest.php
+++ b/test/Horde/Crypt/Blowfish/EcbTest.php
@@ -27,18 +27,6 @@ class Horde_Crypt_Blowfish_EcbTest extends Horde_Test_Case
     /**
      * @dataProvider vectorProvider
      */
-    public function testMcryptDriver($vector)
-    {
-        if (!Horde_Crypt_Blowfish_Mcrypt::supported()) {
-            $this->markTestSkipped();
-        }
-
-        $this->_doTest($vector, Horde_Crypt_Blowfish::IGNORE_OPENSSL);
-    }
-
-    /**
-     * @dataProvider vectorProvider
-     */
     public function testPhpDriver($vector)
     {
         $this->_doTest(

--- a/test/Horde/Crypt/Blowfish/phpunit.xml
+++ b/test/Horde/Crypt/Blowfish/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-crypt-blowfish/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-crypt-blowfish/-/blob/debian-sid/debian/patches/1012_php8.2.patch
